### PR TITLE
Pick plant triggers when plant is finished

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,6 +46,7 @@ class App extends Component {
     this.handleAddSteps = this.handleAddSteps.bind(this)
     this.handleSignInClick = this.handleSignInClick.bind(this)
     this.handleSelectSeed = this.handleSelectSeed.bind(this)
+    this.currentPlantIsFinished = this.currentPlantIsFinished.bind(this)
   }
 
   async componentDidMount() {
@@ -59,7 +60,7 @@ class App extends Component {
     const input = e.target.querySelector('.input-field')
     const stepsAdded = parseInt(input.value, 10)
     input.value = ''
-
+ 
     const body = {
       user_id: this.state.currentUserId,
       number_of_steps: stepsAdded
@@ -255,6 +256,14 @@ class App extends Component {
     }
   }
 
+  async currentPlantIsFinished() {
+    const plantInstanceId = this.state.currentPlantInstanceId
+    console.log('plant is finished')
+    console.log('trigger pick new plant')
+    // await axios.put(`${localhostURL}/plant-instances/${plantInstanceId}`, { completed: true })
+    // this API call needs to be created. 
+  }
+
   render() {
 
     return (
@@ -263,6 +272,7 @@ class App extends Component {
           <PrivateRoute path='/' exact
             component={ HomePlant }
             handleAddSteps={this.handleAddSteps}
+            currentPlantIsFinished={ this.currentPlantIsFinished }
             currentPlantInstanceId={ this.state.currentPlantInstanceId }
             currentPlantStepsProgress={this.state.currentPlantStepsProgress}
             currentPlantStepsRequired={this.state.currentPlantStepsRequired}
@@ -286,6 +296,8 @@ class App extends Component {
             component={ PickSeed }
             handleSelect={ this.handleSelectSeed }
             currentPlantID={ this.state.currentPlantInstanceId }
+            currentPlantStepsProgress={ this.state.currentPlantStepsProgress }
+            currentPlantStepsRequired={ this.state.currentPlantStepsRequired }
           />
           <PrivateRoute path='/profile' component={ Profile } />
           <PrivateRoute path='/logout' component={ LogOut } />

--- a/src/components/forms/PickSeed.js
+++ b/src/components/forms/PickSeed.js
@@ -45,36 +45,37 @@ class PickSeed extends Component {
   }
 
   render() {
-    if(this.props.currentPlantID) {
-      // don't display pick seed if user has a plant
+    if((this.props.currentPlantID) && (this.props.currentPlantStepsProgress < this.props.currentPlantStepsRequired)) {
+      // if you have a current plant and it isn't finished, you shouldn't be allowed here. 
       return (<Redirect to='/' />)
-    } else
-    return (
-      <div className="outermost-container">
-        <CloseForm title="Pick New Seed"/>
-        <Carousel ref="carousel"
-          decorators={ CarouselDecorator }
-          wrapAround
-          dragging
-          initialSlideHeight={800}
-          style={{'height': '80%'}}
-        >
-          {
-            this.state.plants.map(plant => (
-              <SeedChoice
-                key={plant.id}
-                id={plant.id}
-                name={plant.name}
-                steps_required={ plant.steps_required }
-                handleNext={ this.handleNext }
-                handlePrev={ this.handlePrev }
-                handleSelect={ this.props.handleSelect }
-              />
-            ))
-          }
-        </Carousel>
-      </div>
-    )
+    } else {
+      return (
+        <div className="outermost-container">
+          <CloseForm title="Pick New Seed"/>
+          <Carousel ref="carousel"
+            decorators={ CarouselDecorator }
+            wrapAround
+            dragging
+            initialSlideHeight={800}
+            style={{'height': '80%'}}
+          >
+            {
+              this.state.plants.map(plant => (
+                <SeedChoice
+                  key={plant.id}
+                  id={plant.id}
+                  name={plant.name}
+                  steps_required={ plant.steps_required }
+                  handleNext={ this.handleNext }
+                  handlePrev={ this.handlePrev }
+                  handleSelect={ this.props.handleSelect }
+                />
+              ))
+            }
+          </Carousel>
+        </div>
+      )
+    }
   }
 }
 

--- a/src/components/home/HomePlant.js
+++ b/src/components/home/HomePlant.js
@@ -5,6 +5,7 @@ import Navigation from '../shared/Navigation'
 import CurrentPlantContainer from './CurrentPlantContainer'
 import ProgressBar from './ProgressBar'
 import AddStepsContainer from './AddStepsContainer'
+import LinkToPickPlant from './LinkToPickPlant'
 import ViewGarden from '../garden/ViewGarden'
 
 class HomePlant extends React.Component {
@@ -12,20 +13,43 @@ class HomePlant extends React.Component {
     super(props)
 
     this.state = {
-      stepsInput: 0
+      stepsInput: 0,
+      completed: false
     }
+  }
+
+  async updatePlantState() {
+    if((this.props.currentPlantStepsRequired && this.props.currentPlantStepsProgress) && 
+      (this.props.currentPlantStepsProgress >= this.props.currentPlantStepsRequired)) {
+      await this.setState({ ...this.state, completed: true })
+    } else {
+      await this.setState({ ...this.state, completed: false })
+   }
+  }
+
+  async componentDidMount() {
+    await this.updatePlantState()
+  }
+
+  async componentWillReceiveProps(nextProps) {
+    await this.updatePlantState()
   }
 
   getStepsInput(e) {
     e.preventDefault()
     const stepsInput = parseInt(e.target.querySelector('.input-field').value)
-    this.setState({stepsInput})
+    
+    this.setState({ ...this.state, stepsInput })
   }
 
   render() {
-    console.log(this.props.currentPlantStepsProgress, this.props.currentPlantStepsRequired, "progress and required");
+    if((this.props.currentPlantStepsRequired && this.props.currentPlantStepsProgress) && 
+      (this.props.currentPlantStepsProgress >= this.props.currentPlantStepsRequired)) {
+      // if there are values for steps required and progress, and progress is greater than or equal to required, plant is done
+      this.props.currentPlantIsFinished()
+    } 
     if(!this.props.currentPlantInstanceId) {
-      // turning this back on with caution ...
+      // turning this back on with caution...
       return <Redirect to={'/pickseed'} />
     }
     else return (
@@ -34,10 +58,14 @@ class HomePlant extends React.Component {
         <CurrentPlantContainer currentPlantTypeId={ this.props.currentPlantTypeId }
           steps_recorded={ this.props.currentPlantStepsProgress } steps_required={ this.props.currentPlantStepsRequired } newSteps={ this.state.stepsInput }/>
         <ProgressBar percent={ (parseInt(this.props.currentPlantStepsProgress, 10) / parseInt(this.props.currentPlantStepsRequired, 10) * 100) } />
-        <AddStepsContainer addSteps={ (e)=>{
-          this.getStepsInput(e)
-          this.props.handleAddSteps(e)
-        } } />
+        {
+          this.state.completed  
+          ? <LinkToPickPlant /> 
+          : <AddStepsContainer addSteps={(e)=>{
+            this.getStepsInput(e)
+            this.props.handleAddSteps(e)
+          }} /> 
+        }
         <Link to='/garden'>
           <ViewGarden />
         </Link>

--- a/src/components/home/LinkToPickPlant.js
+++ b/src/components/home/LinkToPickPlant.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import GreenButton from '../shared/GreenButton'
+
+const AddStepsContainer = ({ addSteps }) => {
+  return (
+    <div className="input-container" >
+    <p className="center">You finished your plant!!</p>
+    <Link to='/pickseed' style={{width: '95%'}}>
+      <GreenButton text="Pick a new seed!" />
+    </Link>
+    </div>
+  )
+}
+
+export default AddStepsContainer


### PR DESCRIPTION
Still need to implement API call for PATCH plant-instances/:id with a { completed: true } object - I can tackle that next.

There is also still a bug where, after finishing a plant and picking a new seed, you still have to reload the page before the plant will grow upon adding steps. 